### PR TITLE
put: Clean filename usage order

### DIFF
--- a/ftp.js
+++ b/ftp.js
@@ -109,17 +109,22 @@ module.exports = function (RED) {
                     });
                     break;
                 case 'put':
-                    var d = new Date();
-                    var guid = d.getTime().toString();
+                    var newFile = '';
+                    if (msg.payload.filename) {
+                        newFile = node.workdir + msg.payload.filename;
+                    } else if (node.filename == "") {
+                        var d = new Date();
+                        var guid = d.getTime().toString();
 
-                    if (node.fileExtension == "") {
-                        node.fileExtension = ".txt";
+                        if (node.fileExtension == "") {
+                            node.fileExtension = ".txt";
+                        }
+                        newFile = node.workdir + guid + node.fileExtension;
+                    } else {
+                        newFile = node.workdir + node.filename;
                     }
-                    var newFile = node.workdir + guid + node.fileExtension;
-                    var msgData = '';
-                    if (msg.payload.filename)
-                        newFile = msg.payload.filename;
 
+                    var msgData = '';
                     if (msg.payload.filedata)
                         msgData = msg.payload.filedata;
                     else

--- a/ftp.js
+++ b/ftp.js
@@ -111,7 +111,7 @@ module.exports = function (RED) {
                 case 'put':
                     var newFile = '';
                     if (msg.payload.filename) {
-                        newFile = node.workdir + msg.payload.filename;
+                        newFile = msg.payload.filename;
                     } else if (node.filename == "") {
                         var d = new Date();
                         var guid = d.getTime().toString();


### PR DESCRIPTION
Clean filename usage order:
1. if filename is in payload: use workdir and filename from payload
2. if filename in node is not empty: use workdir and filename from node
3. if filename in node is empty: create random name in workdir
