### PR TITLE
node.error with msg for "Catch" node, fix #10

### DIFF
--- a/ftp.js
+++ b/ftp.js
@@ -88,7 +88,7 @@ module.exports = function (RED) {
                     console.log("[http://www.hardingpoint.com] FTP Get:" + ftpfilename);
                     Ftp.get(ftpfilename, function(err, socket){
                         if (err) {
-                            node.error(err);
+                            node.error(err, msg);
                         }else{
                             socket.on("data", function(d){
                                 str += d.toString();
@@ -96,7 +96,7 @@ module.exports = function (RED) {
 
                             socket.on("close", function(err) {
                                 if (err)
-                                    node.error(err);
+                                    node.error(err, msg);
 
                                 node.status({});
                                 msg.payload = {};
@@ -133,7 +133,7 @@ module.exports = function (RED) {
 
                     Ftp.put(buffer, newFile, function(err){
                         if (err)
-                            node.error(err);
+                            node.error(err, msg);
                         else{
                             node.status({});
                             msg.payload.filename = newFile;
@@ -145,7 +145,7 @@ module.exports = function (RED) {
                     console.log("[http://www.hardingpoint.com] FTP Delete:" + msg.payload.filename);
                     var Ftp = new JSFtp(node.ftpConfig.options);
                     Ftp.raw("dele", msg.payload.filename, function(err, data) {
-                        if (err) node.error(err);
+                        if (err) node.error(err, msg);
                         else{
                             node.status({});
                             node.send(msg);
@@ -156,7 +156,7 @@ module.exports = function (RED) {
 
       } catch (error) {
           console.log("Caught Error:" + error);
-         node.error(error);
+         node.error(error, msg);
       }
     });
     } else {

--- a/sftp.js
+++ b/sftp.js
@@ -125,7 +125,7 @@ module.exports = function (RED) {
 
           this.sendMsg = function (err, result) {
               if (err) {
-                  node.error(err.toString());
+                  node.error(err.toString(), msg);
                   node.status({ fill: 'red', shape: 'ring', text: 'failed' });
               }
               node.status({});
@@ -138,13 +138,13 @@ module.exports = function (RED) {
               switch (node.operation) {
                   case 'list':
                       conn.sftp(function (err, sftp) {
-                          if (err) node.error(err);
+                          if (err) node.error(err, msg);
                           sftp.readdir(node.workdir, node.sendMsg);
                       });
                       break;
                   case 'get':
                       conn.sftp(function(err, sftp) {
-                          if (err) node.error(err);
+                          if (err) node.error(err, msg);
                           var ftpfilename = node.workdir + node.filename;
 
                           if (msg.payload.filename)
@@ -176,7 +176,7 @@ module.exports = function (RED) {
                       break;
                   case 'put':
                       conn.sftp(function (err, sftp) {
-                          if (err) node.error(err);
+                          if (err) node.error(err, msg);
                           var d = new Date();
                           var guid = d.getTime().toString();
                           if (node.fileExtension == "") {
@@ -205,14 +205,14 @@ module.exports = function (RED) {
                       break;
                   case 'delete':
                       conn.sftp(function (err, sftp) {
-                      if (err) node.error(err);
+                      if (err) node.error(err, msg);
                           var ftpfilename = node.workdir + node.filename;
                           if (msg.payload.filename)
                               ftpfilename = msg.payload.filename;
                           console.log("Deleting File: " + ftpfilename);
                           sftp.unlink(ftpfilename, function (err) {
                               if (err) {
-                                  node.error(err);
+                                  node.error(err, msg);
                               } else {
                                   console.log("file unlinked");
                                   node.status({});
@@ -225,7 +225,7 @@ module.exports = function (RED) {
               }
           });
           conn.on('error', function(error) {
-            node.error(error);
+            node.error(error, msg);
           });
           conn.connect(node.sftpConfig.options);
 


### PR DESCRIPTION
Add original message to node.error. This allow to use the "Catch" node to handle error by user in flow.
This fix #10 